### PR TITLE
Fixed a serious issue in plugin/Task

### DIFF
--- a/plugin/task.vim
+++ b/plugin/task.vim
@@ -1,8 +1,8 @@
 " Boilerplate
-if (exists("b:did_ftplugin"))
+if (exists("g:loaded_task"))
   finish
 endif
-let b:did_ftplugin = 1
+let g:loaded_task = 1
 
 let s:cpo_save = &cpo
 set cpo&vim


### PR DESCRIPTION
Task plugin was previously checking for 'b:did_ftplugin' buffer
variable and setting it after it is loaded. The 'b:did_ftplugin' buffer
variable should not be used for a plugin, it is specifically meant to be
used by file type plugins (ftplugins). For a plugin, which is loaded by
vim during startup, it should check and set a global variable 'g:var' to
check if it has been loaded or not, the name should be unique enough to
ensure it doesn't clash with any other plugins and cause undesirable
behavior.

Eg.) Since this script is loaded on vim startup, and ftplugins are
loaded on when files are loaded in vim buffers, what happens is they are
skipped entirely because the task plugin, which was loaded during
startup already set the 'b:did_ftplugin' variable which the ftplugin
checks to ensure it isn't loaded multiple times and as a result it is
skipped entirely. This causes file specific behvariour added by the
ftplugins to be missed in the file.
