### PR TITLE
Filetype didn't work for me

### DIFF
--- a/ftdetect/task.vim
+++ b/ftdetect/task.vim
@@ -1,1 +1,4 @@
-autocmd BufNewFile,BufRead todo.txt,*.task,*.tasks	setfiletype task
+autocmd BufNewFile,BufRead todo set filetype=task
+autocmd BufNewFile,BufRead todo.txt set filetype=task
+autocmd BufNewFile,BufRead *.tasks set filetype=task
+autocmd BufNewFile,BufRead *.tasks set filetype=task

--- a/ftdetect/task.vim
+++ b/ftdetect/task.vim
@@ -1,4 +1,4 @@
 autocmd BufNewFile,BufRead todo set filetype=task
 autocmd BufNewFile,BufRead todo.txt set filetype=task
-autocmd BufNewFile,BufRead *.tasks set filetype=task
+autocmd BufNewFile,BufRead *.task set filetype=task
 autocmd BufNewFile,BufRead *.tasks set filetype=task


### PR DESCRIPTION
Filetype, as you wrote, didn't work for me for 'todo.txt, *.task(s)'. This syntax working for me.

Of course,

```
autocmd BufNewFile,BufRead todo.txt,*.task,*.tasks set filetype=task
```

works too.

I also added 'todo' as task filetype because I saw this name for todo files.
